### PR TITLE
feat: make portfolio.afsah.xyz the canonical domain

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,8 +1,11 @@
 name: CI + Pages redirect stub
 
-# The portfolio is deployed on Vercel (name0x0.vercel.app). GitHub Pages now
-# only serves a redirect stub so the legacy https://NAME0x0.github.io link keeps
-# working and bounces to the Vercel deployment.
+# The portfolio is deployed on Vercel and canonical at portfolio.afsah.xyz.
+# GitHub Pages now only serves a redirect stub so the legacy
+# https://NAME0x0.github.io link keeps working and bounces to the live site.
+# Pages cannot issue a real 301, so meta refresh + location.replace is the
+# ceiling here; the stub points straight at the canonical host to avoid
+# chaining through the retired name0x0.vercel.app redirect.
 
 on:
   pull_request:
@@ -62,16 +65,16 @@ jobs:
           <head>
             <meta charset="utf-8">
             <title>Redirecting…</title>
-            <link rel="canonical" href="https://name0x0.vercel.app/">
-            <meta http-equiv="refresh" content="0; url=https://name0x0.vercel.app/">
+            <link rel="canonical" href="https://portfolio.afsah.xyz/">
+            <meta http-equiv="refresh" content="0; url=https://portfolio.afsah.xyz/">
             <meta name="robots" content="noindex">
             <style>html{background:#000;color:#E8E4DE;font-family:system-ui,sans-serif}</style>
             <script>
-              location.replace("https://name0x0.vercel.app/" + location.search + location.hash);
+              location.replace("https://portfolio.afsah.xyz/" + location.search + location.hash);
             </script>
           </head>
           <body>
-            Redirecting to <a href="https://name0x0.vercel.app/">name0x0.vercel.app</a>…
+            Redirecting to <a href="https://portfolio.afsah.xyz/">portfolio.afsah.xyz</a>…
           </body>
           </html>
           HTML

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -78,6 +78,12 @@ jobs:
           </body>
           </html>
           HTML
+          # Links to github.io were shared before the move, including deep ones.
+          # Without a 404.html those hit GitHub's bare error page. The old Pages
+          # site had entirely different routes, so forwarding the path would
+          # mostly land on a 404 at the far end -- send everything to the root
+          # of the canonical host instead, which always resolves.
+          cp _site/index.html _site/404.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Manrope, Space_Grotesk } from "next/font/google";
 import { GeistMono } from "geist/font/mono";
 import { Analytics } from "@vercel/analytics/next";
 import { identity } from "@/content/identity";
+import { SITE_URL } from "@/lib/site";
 import { CursorDot } from "@/components/site/CursorDot";
 import { Footer } from "@/components/site/Footer";
 import { FluidInkMount } from "@/components/site/FluidInkMount";
@@ -27,7 +28,7 @@ const manrope = Manrope({
 
 const monoFont = GeistMono;
 
-const siteUrl = "https://name0x0.vercel.app";
+const siteUrl = SITE_URL;
 const siteDescription =
   "Systems & ML engineer. I build machines that think, on hardware that shouldn't be able to.";
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://name0x0.vercel.app/sitemap.xml",
-    host: "https://name0x0.vercel.app",
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next";
 import { tierOneProjects } from "@/lib/content/projects";
 import { getAllPosts } from "@/lib/content/writing";
+import { SITE_URL } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://name0x0.vercel.app";
+  const baseUrl = SITE_URL;
   const lastModified = new Date();
   const staticRoutes = ["/", "/work", "/writing", "/photos", "/about", "/now", "/cv"];
   const workRoutes = tierOneProjects.map((project) => `/work/${project.slug}`);

--- a/app/writing/rss.xml/route.ts
+++ b/app/writing/rss.xml/route.ts
@@ -1,8 +1,9 @@
 import { getAllPosts } from "@/lib/content/writing";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
 
-const siteUrl = "https://name0x0.vercel.app";
+const siteUrl = SITE_URL;
 
 function escapeXml(value: string): string {
   return value

--- a/docs/BRIEF.md
+++ b/docs/BRIEF.md
@@ -17,7 +17,7 @@
 | Case-study pages, post-v1 content drops | MALD, WebDesk, pane (each gated on owner-supplied war stories) |
 | /writing at launch | Triton-on-Windows post (migrated from existing gist) |
 | /writing post-launch | QLoRA-on-4GB post; OMNI bandwidth-model essay |
-| Domain | No custom domain in v1. Canonical: `name0x0.vercel.app`. `name0x0.github.io` 301s to it. **Line item: buy custom domain (name0x0.dev already in package.json metadata) before any public launch campaign** — redirect equity transfers cleanly |
+| Domain | Canonical: `portfolio.afsah.xyz` (afsah.xyz registered at Porkbun, `portfolio` CNAME → Vercel). `name0x0.vercel.app` 308s to it via a host-matched rule in `next.config.mjs`; `name0x0.github.io` bounces via the Pages stub. Root `afsah.xyz` reserved for a separate landing page |
 | Hosting | Vercel primary; GitHub Pages repo becomes redirect stub |
 | Scroll/animation | Lenis + Framer Motion; port AGI-Ledger particle-morph patterns (verified in source: MeshSurfaceSampler → single particle buffer, custom point shader dissolve, canvas glow sprite, `frameloop="never"` when inactive, DPR capped 1.25–1.5 via PerformanceMonitor) |
 | Analytics | Vercel Analytics only; funnel events per §7 of master prompt; documented in `docs/ANALYTICS.md` |

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -31,11 +31,11 @@ GitHub Actions shared runners give Lighthouse inconsistent CPU, so a single-run 
 
 ## Launch
 
-- [ ] Merge to main → production deploy on name0x0.vercel.app.
-- [ ] github.io redirect: the GitHub Pages surface cannot serve real 301s. Options, pick one:
-  1. Replace Pages content with a stub page: meta refresh + `<link rel="canonical" href="https://name0x0.vercel.app/">` + a visible link. (Do this at minimum.)
-  2. Better: buy the custom domain (name0x0.dev is already in package metadata history), point it at Vercel, and make it canonical — then both vercel.app and github.io defer to it. Redirect equity transfers cleanly whenever you do this; before any public campaign is the right time.
-- [ ] Search Console: add the property, submit sitemap.xml.
+- [x] Merge to main → production deploy on Vercel.
+- [x] Custom domain: `portfolio.afsah.xyz` (afsah.xyz at Porkbun; explicit `portfolio` CNAME → `0fbebf97c52ff01e.vercel-dns-017.com`, which overrides the `*.afsah.xyz` parking wildcard). Canonical everywhere via `lib/site.ts`.
+- [x] `name0x0.vercel.app` → 308 to the canonical host (host-matched redirect in `next.config.mjs`; preview deploys unaffected).
+- [x] `name0x0.github.io` → Pages stub points at the canonical host directly (Pages cannot serve real 301s; meta refresh + `location.replace` is the ceiling).
+- [ ] Search Console: add `portfolio.afsah.xyz` as the property, submit sitemap.xml. Keep the old properties registered until their traffic drops to zero so the redirects are observed.
 - [ ] Link-preview test: paste /, /work/ava, /writing/triton-fla-bitsandbytes-windows into WhatsApp/Discord/X — OG images should render with status labels.
 
 ## Distribution (the 6–18 month campaign)

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,7 @@
+// Canonical origin for the site. Everything that emits an absolute URL —
+// metadataBase, JSON-LD, robots, sitemap, RSS — reads it from here so the four
+// of them can never drift apart again.
+export const SITE_URL = "https://portfolio.afsah.xyz";
+
+// Hosts that used to be canonical and now 308 here (see next.config.mjs).
+export const LEGACY_HOST = "name0x0.vercel.app";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,6 +34,19 @@ const nextConfig = {
   poweredByHeader: false,
   compress: true,
   generateEtags: true,
+  // The .vercel.app production hostname is system-assigned and cannot be set to
+  // redirect from the dashboard, so the old canonical is retired here instead.
+  // Host-matched, so preview deployments (*-git-*.vercel.app) are unaffected.
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "name0x0.vercel.app" }],
+        destination: "https://portfolio.afsah.xyz/:path*",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "https://github.com/NAME0x0/NAME0x0.github.io.git"
   },
-  "homepage": "https://name0x0.vercel.app",
+  "homepage": "https://portfolio.afsah.xyz",
   "dependencies": {
     "@gsap/react": "^2.1.2",
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
Points the site at the newly registered custom domain and retires the two hosts that used to be canonical.

## Domain

`portfolio.afsah.xyz` is live and serving. DNS is an explicit `CNAME portfolio -> 0fbebf97c52ff01e.vercel-dns-017.com` at Porkbun — explicit, because the existing `*.afsah.xyz` parking wildcard was catching the subdomain and pointing it at Porkbun's parking page, which is why Vercel initially reported Invalid Configuration.

## Changes

- **`lib/site.ts` (new)** — the canonical origin was hardcoded in four separate files, which is exactly how these drift apart. It now lives in one place; `metadataBase`, the WebSite JSON-LD, `robots.ts`, `sitemap.ts` and the RSS feed all read from it.
- **`next.config.mjs`** — host-matched 308 from `name0x0.vercel.app`. The production `.vercel.app` hostname is system-assigned and has no redirect option in the dashboard, so it has to be handled in code. The host match is exact, so preview deployments on `*-git-*.vercel.app` are untouched.
- **`.github/workflows/nextjs.yml`** — the Pages stub now points straight at the canonical host instead of chaining through the retired vercel.app redirect. Pages cannot serve a real 301; meta refresh + `location.replace` is the ceiling.
- **`docs/BRIEF.md`, `docs/LAUNCH.md`** — the domain line item said "no custom domain in v1, buy one before launch". Done, so both now describe what actually shipped.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` all clean locally.
- Build output grepped: zero occurrences of `name0x0.vercel.app` under `.next/server`, canonical present across the prerendered pages.
- `nslookup -type=CNAME portfolio.afsah.xyz 8.8.8.8` returns the Vercel target; `curl -I https://portfolio.afsah.xyz` returns 200 with the CSP intact.

## Follow-up (not in this PR)

- Search Console: register `portfolio.afsah.xyz`, submit the sitemap, keep the old properties until their traffic drops to zero so the redirects are observed.
- Root `afsah.xyz` is still on Porkbun parking, reserved for a separate landing page.
- The `*.afsah.xyz` wildcard means any future subdomain needs its own explicit record. Worth deleting eventually so typos 404 instead of serving a parking ad.
